### PR TITLE
Skip unselected sections in generated config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,34 +3,6 @@
 Language: **Python**
 Format: **agent.md**
 
-## Process Time / Token Reduction
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Authentication
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Performance
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Code Quality
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Data Layer
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Testing
-- Enforcement: Strictly Enforced
-- (none selected)
-
-## Web / GUI Libraries
-- Enforcement: Strictly Enforced
-- (none selected)
-
 ## Miscellaneous
 - Enforcement: Strictly Enforced
 - Automatically push code changes to a PR and merge to main

--- a/config_app.py
+++ b/config_app.py
@@ -317,15 +317,16 @@ class ConfigApp(QWidget):
         ]
 
         for sec in order:
-            header = self.section_display_names.get(sec, sec.replace("_", " ").title())
-            lines.append(f"## {header}")
             gb = self.sections.get(sec)
             if not gb:
-                lines.append("- (no options)")
-                lines.append("")
                 continue
 
             selected = [cb.text() for cb in gb.findChildren(QCheckBox) if cb.isChecked()]
+            if not selected:
+                continue
+
+            header = self.section_display_names.get(sec, sec.replace("_", " ").title())
+            lines.append(f"## {header}")
 
             # enforcement: default to Strictly Enforced unless the 'Allow AI...' option (id 2) is selected
             bg = self.section_enforcement.get(sec)
@@ -339,11 +340,8 @@ class ConfigApp(QWidget):
                 enforcement_text = "Strictly Enforced"
 
             lines.append(f"- Enforcement: {enforcement_text}")
-            if not selected:
-                lines.append("- (none selected)")
-            else:
-                for s in selected:
-                    lines.append(f"- {s}")
+            for s in selected:
+                lines.append(f"- {s}")
             lines.append("")
 
         # append custom behavior

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,19 +1,25 @@
 from PyQt5.QtWidgets import QApplication, QCheckBox
 from config_app import ConfigApp
 
-app = QApplication([])
-win = ConfigApp()
-# Ensure sections are built for Python
-win.update_sections('Python')
-# Select first option in authentication
-gb = win.sections.get('authentication')
-if gb:
-    cbs = gb.findChildren(QCheckBox)
-    if cbs:
-        cbs[0].setChecked(True)
-# Set enforcement for authentication to 'Allow AI...' (id 2)
-bg = win.section_enforcement.get('authentication')
-if bg and bg.button(2):
-    bg.button(2).setChecked(True)
 
-print(win.generate_markdown())
+def run():
+    app = QApplication([])
+    win = ConfigApp()
+    # Ensure sections are built for Python
+    win.update_sections('Python')
+    # Select first option in authentication
+    gb = win.sections.get('authentication')
+    if gb:
+        cbs = gb.findChildren(QCheckBox)
+        if cbs:
+            cbs[0].setChecked(True)
+    # Set enforcement for authentication to 'Allow AI...' (id 2)
+    bg = win.section_enforcement.get('authentication')
+    if bg and bg.button(2):
+        bg.button(2).setChecked(True)
+
+    print(win.generate_markdown())
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_generate_markdown.py
+++ b/tests/test_generate_markdown.py
@@ -7,19 +7,30 @@ def test_default_enforcement(qtbot):
     win = ConfigApp()
     qtbot.addWidget(win)
     win.update_sections('Python')
+    auth_gb = win.sections.get('authentication')
+    first_label = None
+    if auth_gb:
+        cb = auth_gb.findChildren(QCheckBox)[0]
+        first_label = cb.text()
+        cb.setChecked(True)
     md = win.generate_markdown()
     assert '## Authentication' in md
-    assert 'Enforcement: Strictly Enforced' in md
+    assert '- Enforcement: Strictly Enforced' in md
+    assert f'- {first_label}' in md
 
 def test_allow_ai_enforcement(qtbot):
     win = ConfigApp()
     qtbot.addWidget(win)
     win.update_sections('Python')
+    auth_gb = win.sections.get('authentication')
+    if auth_gb:
+        auth_gb.findChildren(QCheckBox)[0].setChecked(True)
     bg = win.section_enforcement.get('authentication')
     # set to id 2 (Allow AI)
     if bg and bg.button(2):
         bg.button(2).setChecked(True)
     md = win.generate_markdown()
+    assert '## Authentication' in md
     assert 'Enforcement: Allow AI to use better option if one applies' in md
 
 def test_custom_behavior_included(qtbot):
@@ -32,10 +43,21 @@ def test_custom_behavior_included(qtbot):
     assert 'Do this and that' in md
 
 
-def test_process_time_section_present(qtbot):
+def test_sections_without_selection_skipped(qtbot):
     win = ConfigApp()
     qtbot.addWidget(win)
     win.update_sections('Python')
+    md = win.generate_markdown()
+    assert '## Authentication' not in md
+
+
+def test_process_time_section_selected_included(qtbot):
+    win = ConfigApp()
+    qtbot.addWidget(win)
+    win.update_sections('Python')
+    pt_gb = win.sections.get('process_time_token_reduction')
+    if pt_gb:
+        pt_gb.findChildren(QCheckBox)[0].setChecked(True)
     md = win.generate_markdown()
     assert '## Process Time / Token Reduction' in md
 
@@ -50,4 +72,5 @@ def test_auto_push_option_in_misc(qtbot):
             if cb.text() == 'Automatically push code changes to a PR and merge to main':
                 cb.setChecked(True)
     md = win.generate_markdown()
+    assert '## Miscellaneous' in md
     assert 'Automatically push code changes to a PR and merge to main' in md


### PR DESCRIPTION
## Summary
- Avoid writing config sections with no selected options
- Extend tests for new skip behavior and guard smoke test execution
- Trim AGENTS instructions file to only the chosen option

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af288b50548322bed1cb56a3e19f93