### PR TITLE
Fix Qt test failure in headless environments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Ensure Qt uses an offscreen platform so tests can run in headless environments
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')


### PR DESCRIPTION
## Summary
- ensure Qt uses an offscreen platform during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0ba3420c083228aaa1d522d552fd4