### PR TITLE
Use PyInstaller noconsole option to hide console window

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -25,7 +25,7 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path . -Filter *.py | ForEach-Object {
-            pyinstaller --onefile $_.Name
+            pyinstaller --onefile --noconsole $_.Name
           }
 
       - name: Upload executables

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python -m pip install -r requirements.txt
 # run app
 & .venv/Scripts/python.exe config_app.py
 
-# build standalone exe
+# build standalone exe (no console window)
 & .venv/Scripts/Activate.ps1
 & .\build_exe.ps1
 # result: dist\config_app.exe
@@ -25,5 +25,6 @@ python -m pip install -r requirements.txt
 
 Notes
 - The build script converts the provided PNG in `img/` to `img/app.ico` and embeds it; `img/app.ico` is present in the repo.
+- The build uses PyInstaller's `--noconsole` option so the executable runs without an attached console window.
 - If distributing the exe to other machines, ensure the target has the appropriate MSVC runtime.
 - CI: consider adding a GitHub Actions workflow to build artifacts on push.

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -1,0 +1,2 @@
+# Build standalone executable without console window
+pyinstaller --onefile --noconsole --icon img/app.ico config_app.py


### PR DESCRIPTION
## Summary
- Build Windows executables without a console window using PyInstaller's `--noconsole`
- Add PowerShell build script and document the new behavior

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c482764883229ae666a88a9b4900