### PR TITLE
chore: remove dist path from build workflow

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -25,14 +25,14 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path . -Filter *.py | ForEach-Object {
-            pyinstaller --onefile --noconsole $_.Name
+            pyinstaller --onefile --noconsole --distpath . $_.Name
           }
 
       - name: Upload executables
         uses: actions/upload-artifact@v4
         with:
           name: executables
-          path: dist
+          path: "*.exe"
 
       - name: Show download link
         run: echo "Download the executables at https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"


### PR DESCRIPTION
## Summary
- output executables in repository root and upload them using a glob

## Testing
- `if [ -n "$(git ls-files '*.py')" ]; then python -m py_compile $(git ls-files '*.py'); else echo 'No Python files to compile'; fi`


------
https://chatgpt.com/codex/tasks/task_e_68b0ca006f6883228e5531f002cc14dc